### PR TITLE
feat: add get_user_inventory service, tool and tests

### DIFF
--- a/.changeset/rude-pears-wait.md
+++ b/.changeset/rude-pears-wait.md
@@ -1,0 +1,5 @@
+---
+'discogs-mcp-server': minor
+---
+
+feat: add get_user_inventory service, tool and tests

--- a/TOOLS.md
+++ b/TOOLS.md
@@ -319,6 +319,25 @@
 
 ## Marketplace Tools
 
+#### `get_user_inventory`
+**Description**: Returns the list of listings in a user's inventory
+
+**Inputs**:
+- `username` (string, required): The username whose inventory to get
+- `page` (integer, optional): Page number (minimum: 1)
+- `per_page` (integer, optional): Items per page (minimum: 1, maximum: 100)
+- `status` (string, optional): Filter by status (For Sale, Expired, Draft, Pending)
+- `sort` (string, optional): Sort field (listed, price, item, artist, label, catno, audio, status, location)
+- `sort_order` (string, optional): Sort direction (asc, desc)
+
+**Returns**: List of inventory items as JSON string, including:
+- Pagination information (page, pages, items count)
+- List of listings, each containing:
+  - Listing details (ID, status, condition, price)
+  - Release information (ID, description, artist, title)
+  - Seller information (ID, username, stats)
+  - Shipping and payment details
+
 #### `get_marketplace_listing`
 **Description**: Get a listing from the marketplace
 

--- a/src/services/user/inventory.ts
+++ b/src/services/user/inventory.ts
@@ -1,0 +1,37 @@
+import { isDiscogsError } from '../../errors.js';
+import {
+  type UserInventoryGetParams,
+  type UserInventoryResponse,
+  UserInventoryResponseSchema,
+} from '../../types/user/index.js';
+import { BaseUserService } from '../index.js';
+
+/**
+ * Service for Discogs User Inventory operations
+ */
+export class UserInventoryService extends BaseUserService {
+  /**
+   * Returns the list of listings in a user's inventory
+   * @param params - Parameters for the request including username and optional pagination/sorting
+   * @returns {UserInventoryResponse} A paginated response containing the user's inventory
+   * @throws {DiscogsResourceNotFoundError} If the username cannot be found
+   * @throws {Error} If there's an unexpected error
+   */
+  async get({ username, ...options }: UserInventoryGetParams): Promise<UserInventoryResponse> {
+    try {
+      const response = await this.request<UserInventoryResponse>(`/${username}/inventory`, {
+        params: options,
+      });
+
+      // Validate the response using Zod schema
+      const validatedResponse = UserInventoryResponseSchema.parse(response);
+      return validatedResponse;
+    } catch (error) {
+      if (isDiscogsError(error)) {
+        throw error;
+      }
+
+      throw new Error(`Failed to get inventory: ${String(error)}`);
+    }
+  }
+}

--- a/src/tools/marketplace.ts
+++ b/src/tools/marketplace.ts
@@ -1,6 +1,7 @@
 import { FastMCP, Tool } from 'fastmcp';
 import { formatDiscogsError } from '../errors.js';
 import { MarketplaceService } from '../services/marketplace.js';
+import { UserInventoryService } from '../services/user/inventory.js';
 import {
   ListingGetParamsSchema,
   ListingIdParamSchema,
@@ -13,6 +14,7 @@ import {
   OrdersParamsSchema,
 } from '../types/marketplace.js';
 import { ReleaseParamsSchema } from '../types/release.js';
+import { UserInventoryGetParamsSchema } from '../types/user/index.js';
 
 /**
  * MCP tool for creating a marketplace listing
@@ -170,6 +172,25 @@ export const getMarketplaceReleaseStatsTool: Tool<undefined, typeof ReleaseParam
 };
 
 /**
+ * MCP tool for getting a user's inventory
+ */
+export const getUserInventoryTool: Tool<undefined, typeof UserInventoryGetParamsSchema> = {
+  name: 'get_user_inventory',
+  description: `Returns the list of listings in a user's inventory`,
+  parameters: UserInventoryGetParamsSchema,
+  execute: async (args) => {
+    try {
+      const userInventoryService = new UserInventoryService();
+      const inventory = await userInventoryService.get(args);
+
+      return JSON.stringify(inventory);
+    } catch (error) {
+      throw formatDiscogsError(error);
+    }
+  },
+};
+
+/**
  * MCP tool for editing a marketplace order
  */
 export const editMarketplaceOrderTool: Tool<undefined, typeof OrderEditParamsSchema> = {
@@ -208,6 +229,7 @@ export const updateMarketplaceListingTool: Tool<undefined, typeof ListingUpdateP
 };
 
 export function registerMarketplaceTools(server: FastMCP): void {
+  server.addTool(getUserInventoryTool);
   server.addTool(getMarketplaceListingTool);
   server.addTool(createMarketplaceListingTool);
   server.addTool(updateMarketplaceListingTool);

--- a/src/types/common.ts
+++ b/src/types/common.ts
@@ -67,12 +67,14 @@ export const PaginatedResponseSchema = <T extends z.ZodType, K extends string>(
       per_page: z.number().int().min(0).optional(),
       pages: z.number().int().min(0),
       items: z.number().int().min(0),
-      urls: z.object({
-        first: z.string().url().optional(),
-        prev: z.string().url().optional(),
-        next: z.string().url().optional(),
-        last: z.string().url().optional(),
-      }),
+      urls: z
+        .object({
+          first: z.string().url().optional(),
+          prev: z.string().url().optional(),
+          next: z.string().url().optional(),
+          last: z.string().url().optional(),
+        })
+        .optional(),
     }),
     [resultsFieldName]: z.array(itemSchema),
   });

--- a/src/types/marketplace.ts
+++ b/src/types/marketplace.ts
@@ -64,15 +64,15 @@ const ListingReleaseSchema = z.object({
 });
 
 export const PriceSchema = z.object({
-  currency: CurrencyCodeSchema,
-  value: z.number(),
+  currency: CurrencyCodeSchema.optional(),
+  value: z.number().optional(),
 });
 
 export const OriginalPriceSchema = z.object({
-  curr_abbr: CurrencyCodeSchema,
-  curr_id: z.number(),
-  formatted: z.string(),
-  value: z.number(),
+  curr_abbr: CurrencyCodeSchema.optional(),
+  curr_id: z.number().optional(),
+  formatted: z.string().optional(),
+  value: z.number().optional(),
 });
 
 export const OrderMessageSchema = z.object({
@@ -112,7 +112,7 @@ export const OrderMessageSchema = z.object({
   new: z.number().optional(),
 });
 
-export const SaleStatusSchema = z.enum(['For Sale', 'Expired', 'Draft']);
+export const SaleStatusSchema = z.enum(['For Sale', 'Expired', 'Draft', 'Pending']);
 
 /**
  * The listing schema
@@ -138,7 +138,7 @@ export const ListingSchema = z.object({
     id: z.number(),
     username: z.string(),
     resource_url: urlOrEmptySchema().optional(),
-    avatar_url: urlOrEmptySchema(),
+    avatar_url: urlOrEmptySchema().optional(),
     stats: z.object({
       rating: z.string(),
       stars: z.number(),

--- a/src/types/user/index.ts
+++ b/src/types/user/index.ts
@@ -1,4 +1,5 @@
 export * from './collection.js';
+export * from './inventory.js';
 export * from './lists.js';
 export * from './profile.js';
 export * from './wants.js';

--- a/src/types/user/inventory.ts
+++ b/src/types/user/inventory.ts
@@ -1,0 +1,25 @@
+import { z } from 'zod';
+import { PaginatedResponseSchema, QueryParamsSchema, UsernameInputSchema } from '../common.js';
+import { ListingSchema, SaleStatusSchema } from '../marketplace.js';
+
+export const UserInventoryGetParamsSchema = UsernameInputSchema.extend({
+  status: SaleStatusSchema.optional(),
+}).merge(
+  QueryParamsSchema([
+    'listed',
+    'price',
+    'item',
+    'artist',
+    'label',
+    'catno',
+    'audio',
+    'status',
+    'location',
+  ]),
+);
+
+export const UserInventoryResponseSchema = PaginatedResponseSchema(ListingSchema, 'listings');
+
+export type UserInventoryGetParams = z.infer<typeof UserInventoryGetParamsSchema>;
+
+export type UserInventoryResponse = z.infer<typeof UserInventoryResponseSchema>;

--- a/tests/services/user/inventory.test.ts
+++ b/tests/services/user/inventory.test.ts
@@ -1,0 +1,140 @@
+// Mock imports need to go before all other imports
+import '../../mocks/discogsService';
+
+import { beforeEach, describe, expect, it } from 'vitest';
+import { UserInventoryService } from '../../../src/services/user/inventory';
+import type { UserInventoryResponse } from '../../../src/types/user';
+
+// Mock inventory response
+const mockInventoryResponse: UserInventoryResponse = {
+  pagination: {
+    page: 1,
+    per_page: 50,
+    pages: 2,
+    items: 75,
+    urls: {
+      first: 'https://api.discogs.com/users/testuser/inventory?page=1',
+      next: 'https://api.discogs.com/users/testuser/inventory?page=2',
+      last: 'https://api.discogs.com/users/testuser/inventory?page=2',
+    },
+  },
+  listings: [
+    {
+      id: 123,
+      status: 'For Sale',
+      condition: 'Mint (M)',
+      price: {
+        value: 29.99,
+        currency: 'USD',
+      },
+      allow_offers: true,
+      sleeve_condition: 'Near Mint (NM or M-)',
+      comments: 'Test listing',
+      audio: true,
+      resource_url: 'https://api.discogs.com/marketplace/listings/123',
+      uri: 'https://www.discogs.com/sell/item/123',
+      ships_from: 'US',
+      posted: '2024-01-01T00:00:00Z',
+      original_price: {
+        value: 29.99,
+        curr_abbr: 'USD',
+      },
+      seller: {
+        id: 789,
+        username: 'testuser',
+        stats: {
+          rating: '4.5',
+          stars: 4.5,
+          total: 100,
+        },
+        min_order_total: 0,
+        html_url: 'https://www.discogs.com/user/testuser',
+        uid: 789,
+        url: 'https://api.discogs.com/users/testuser',
+        payment: 'PayPal',
+        shipping: 'Worldwide',
+        resource_url: 'https://api.discogs.com/users/testuser',
+        avatar_url: 'https://api.discogs.com/images/u-789-1.jpg',
+      },
+      release: {
+        id: 456,
+        description: 'Test Release',
+        resource_url: 'https://api.discogs.com/releases/456',
+        stats: {
+          community: {
+            in_wantlist: 10,
+            in_collection: 20,
+          },
+        },
+        year: 2020,
+        artist: 'Test Artist',
+        title: 'Test Title',
+        format: 'Vinyl, LP',
+        thumbnail: 'https://api.discogs.com/images/R-456-1.jpg',
+      },
+    },
+  ],
+};
+
+describe('UserInventoryService', () => {
+  let service: UserInventoryService;
+
+  beforeEach(() => {
+    service = new UserInventoryService();
+  });
+
+  describe('get', () => {
+    it('should return a validated inventory response', async () => {
+      (service as any).request.mockResolvedValueOnce(mockInventoryResponse);
+
+      const result = await service.get({ username: 'testuser' });
+
+      expect(result).toEqual(mockInventoryResponse);
+      expect(service['request']).toHaveBeenCalledWith('/testuser/inventory', {
+        params: {},
+      });
+    });
+
+    it('should pass query parameters to the API', async () => {
+      (service as any).request.mockResolvedValueOnce(mockInventoryResponse);
+
+      const params = {
+        username: 'testuser',
+        page: 2,
+        per_page: 25,
+        status: 'Draft' as const,
+        sort: 'price',
+        sort_order: 'desc' as const,
+      };
+
+      await service.get(params);
+
+      expect(service['request']).toHaveBeenCalledWith('/testuser/inventory', {
+        params: {
+          page: 2,
+          per_page: 25,
+          status: 'Draft',
+          sort: 'price',
+          sort_order: 'desc',
+        },
+      });
+    });
+
+    it('should handle Discogs resource not found errors properly', async () => {
+      const discogsError = new Error('Discogs API Error');
+      discogsError.name = 'DiscogsResourceNotFoundError';
+      (service as any).request.mockRejectedValueOnce(discogsError);
+
+      await expect(service.get({ username: 'nonexistent' })).rejects.toThrow(
+        'DiscogsResourceNotFoundError',
+      );
+    });
+
+    it('should handle validation errors properly', async () => {
+      const invalidResponse = { ...mockInventoryResponse, listings: [{ id: 'not-a-number' }] };
+      (service as any).request.mockResolvedValueOnce(invalidResponse);
+
+      await expect(service.get({ username: 'testuser' })).rejects.toThrow();
+    });
+  });
+});

--- a/tests/tools/marketplace.test.ts
+++ b/tests/tools/marketplace.test.ts
@@ -159,7 +159,7 @@ describe('Marketplace Tools', () => {
                     price: { type: 'number' },
                     status: {
                       type: 'string',
-                      enum: ['For Sale', 'Expired', 'Draft'],
+                      enum: ['For Sale', 'Expired', 'Draft', 'Pending'],
                     },
                     format_quantity: { type: 'number' },
                     comments: { type: 'string' },
@@ -550,7 +550,7 @@ describe('Marketplace Tools', () => {
                     price: { type: 'number' },
                     status: {
                       type: 'string',
-                      enum: ['For Sale', 'Expired', 'Draft'],
+                      enum: ['For Sale', 'Expired', 'Draft', 'Pending'],
                     },
                     format_quantity: { type: 'number' },
                     comments: { type: 'string' },


### PR DESCRIPTION
### Description

Add a tool for getting a user's inventory.

### Checklist

- [ ] It's useful if your PR references an issue where it is discussed ahead of time
- [x] Adhere to [semantic messaging](https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716) and prefix your PR title with `feat:`, `fix:`, `chore:`, `docs:`, etc.
- [x] I’ve added tests if needed
- [x] I’ve updated documentation if applicable
- [x] I’ve tested this locally
- [x] Add a changeset (`pnpm changeset`) if necessary

### Tests and linting

- [x] Run the tests with `pnpm test`.
- [x] Run the lint check with `pnpm lint`.
- [x] Run the code formatting (prettier) check with `pnpm format`.