### PR TITLE
feat: add edit_user_collection_custom_field_value tool

### DIFF
--- a/.changeset/curly-dolls-dig.md
+++ b/.changeset/curly-dolls-dig.md
@@ -1,0 +1,5 @@
+---
+'discogs-mcp-server': minor
+---
+
+feat: add edit_user_collection_custom_field_value tool

--- a/README.md
+++ b/README.md
@@ -193,7 +193,6 @@ Any changes to local code will require Claude to be restarted to take effect. Al
 - OAuth support
 - Missing tools:
   - Inventory uploading
-  - Editing collection custom fields
 
 ## License
 

--- a/TOOLS.md
+++ b/TOOLS.md
@@ -185,6 +185,19 @@
 
 **Returns**: List of custom fields as JSON string
 
+#### `edit_user_collection_custom_field_value`
+**Description**: Edit a custom field value for a release in a user's collection
+
+**Inputs**:
+- `username` (string, required): The username whose collection to access
+- `folder_id` (integer, required): The ID of the folder containing the release
+- `release_id` (number, required): The ID of the release to edit
+- `instance_id` (number, required): The instance ID of the release in the collection
+- `field_id` (integer, required): The ID of the custom field to edit
+- `value` (string, required): The new value for the custom field
+
+**Returns**: Success status as JSON string
+
 #### `get_user_collection_value`
 **Description**: Returns the minimum, median, and maximum value of a user's collection
 

--- a/src/services/user/collection.ts
+++ b/src/services/user/collection.ts
@@ -1,6 +1,7 @@
 import { isDiscogsError } from '../../errors.js';
 import { UsernameInput } from '../../types/common.js';
 import {
+  type UserCollectionCustomFieldEditParams,
   type UserCollectionCustomFields,
   UserCollectionCustomFieldsSchema,
   type UserCollectionFolder,
@@ -150,6 +151,41 @@ export class UserCollectionService extends BaseUserService {
       }
 
       throw new Error(`Failed to delete release from folder: ${String(error)}`);
+    }
+  }
+
+  /**
+   * Edit a custom field value for a release in a user's collection
+   *
+   * @param params The parameters for the custom field value edit
+   * @throws {DiscogsAuthenticationError} If authentication fails
+   * @throws {DiscogsPermissionError} If trying to edit a custom field value of another user
+   * @throws {DiscogsResourceNotFoundError} If the username, folder_id, release_id, or instance_id cannot be found
+   * @throws {DiscogsValidationFailedError} If the field is a dropdown and the value is not in the list of options
+   * @throws {Error} If there's an unexpected error
+   */
+  async editCustomFieldValue({
+    username,
+    folder_id,
+    release_id,
+    instance_id,
+    field_id,
+    value,
+  }: UserCollectionCustomFieldEditParams): Promise<void> {
+    try {
+      await this.request<void>(
+        `/${username}/collection/folders/${folder_id}/releases/${release_id}/instances/${instance_id}/fields/${field_id}`,
+        {
+          method: 'POST',
+          body: { value },
+        },
+      );
+    } catch (error) {
+      if (isDiscogsError(error)) {
+        throw error;
+      }
+
+      throw new Error(`Failed to edit custom field value: ${String(error)}`);
     }
   }
 

--- a/src/tools/userCollection.ts
+++ b/src/tools/userCollection.ts
@@ -3,6 +3,7 @@ import { formatDiscogsError } from '../errors.js';
 import { UserService } from '../services/user/index.js';
 import { UsernameInputSchema } from '../types/common.js';
 import {
+  UserCollectionCustomFieldEditParamsSchema,
   UserCollectionFolderCreateParamsSchema,
   UserCollectionFolderEditParamsSchema,
   UserCollectionFolderParamsSchema,
@@ -96,6 +97,28 @@ export const deleteUserCollectionFolderTool: Tool<
       await userService.collection.deleteFolder(args);
 
       return 'Folder deleted successfully';
+    } catch (error) {
+      throw formatDiscogsError(error);
+    }
+  },
+};
+
+/**
+ * MCP tool for editing a custom field value for a release in a Discogs user's collection
+ */
+export const editUserCollectionCustomFieldValueTool: Tool<
+  undefined,
+  typeof UserCollectionCustomFieldEditParamsSchema
+> = {
+  name: 'edit_user_collection_custom_field_value',
+  description: `Edit a custom field value for a release in a user's collection`,
+  parameters: UserCollectionCustomFieldEditParamsSchema,
+  execute: async (args) => {
+    try {
+      const userService = new UserService();
+      await userService.collection.editCustomFieldValue(args);
+
+      return 'Custom field value edited successfully';
     } catch (error) {
       throw formatDiscogsError(error);
     }
@@ -299,5 +322,6 @@ export function registerUserCollectionTools(server: FastMCP): void {
   server.addTool(moveReleaseInUserCollectionTool);
   server.addTool(deleteReleaseFromUserCollectionFolderTool);
   server.addTool(getUserCollectionCustomFieldsTool);
+  server.addTool(editUserCollectionCustomFieldValueTool);
   server.addTool(getUserCollectionValueTool);
 }

--- a/src/types/user/collection.ts
+++ b/src/types/user/collection.ts
@@ -32,6 +32,18 @@ export const UserCollectionCustomFieldsSchema = z.object({
 });
 
 /**
+ * Schema for a Discogs user collection custom field edit parameters
+ */
+export const UserCollectionCustomFieldEditParamsSchema = UsernameInputSchema.merge(
+  FolderIdParamSchema().extend({
+    value: z.string(),
+    release_id: z.union([z.number(), z.string()]),
+    instance_id: z.union([z.number(), z.string()]),
+    field_id: z.number(),
+  }),
+);
+
+/**
  * Schema for a Discogs user collection folder
  */
 export const UserCollectionFolderSchema = z.object({
@@ -168,6 +180,13 @@ export const UserCollectionValueSchema = z.object({
  * TypeScript type for custom fields in a user's collection
  */
 export type UserCollectionCustomFields = z.infer<typeof UserCollectionCustomFieldsSchema>;
+
+/**
+ * TypeScript type for a Discogs user collection custom field edit parameters
+ */
+export type UserCollectionCustomFieldEditParams = z.infer<
+  typeof UserCollectionCustomFieldEditParamsSchema
+>;
 
 /**
  * TypeScript type for a Discogs user collection folder

--- a/tests/services/user/collection.test.ts
+++ b/tests/services/user/collection.test.ts
@@ -1450,4 +1450,95 @@ describe('UserCollectionService', () => {
       ).rejects.toThrow('DiscogsValidationFailedError');
     });
   });
+
+  describe('editCustomFieldValue', () => {
+    it('should edit a custom field value successfully', async () => {
+      (service as any).request.mockResolvedValueOnce(undefined);
+
+      await service.editCustomFieldValue({
+        username: 'testuser',
+        folder_id: 1,
+        release_id: 123,
+        instance_id: 456,
+        field_id: 1,
+        value: 'Mint',
+      });
+
+      expect(service['request']).toHaveBeenCalledWith(
+        '/testuser/collection/folders/1/releases/123/instances/456/fields/1',
+        {
+          method: 'POST',
+          body: { value: 'Mint' },
+        },
+      );
+    });
+
+    it('should handle Discogs authentication errors properly', async () => {
+      const discogsError = new Error('Discogs API Error');
+      discogsError.name = 'DiscogsAuthenticationError';
+      (service as any).request.mockRejectedValueOnce(discogsError);
+
+      await expect(
+        service.editCustomFieldValue({
+          username: 'testuser',
+          folder_id: 1,
+          release_id: 123,
+          instance_id: 456,
+          field_id: 1,
+          value: 'Mint',
+        }),
+      ).rejects.toThrow('DiscogsAuthenticationError');
+    });
+
+    it('should handle Discogs permission errors properly', async () => {
+      const discogsError = new Error('Discogs API Error');
+      discogsError.name = 'DiscogsPermissionError';
+      (service as any).request.mockRejectedValueOnce(discogsError);
+
+      await expect(
+        service.editCustomFieldValue({
+          username: 'otheruser',
+          folder_id: 1,
+          release_id: 123,
+          instance_id: 456,
+          field_id: 1,
+          value: 'Mint',
+        }),
+      ).rejects.toThrow('DiscogsPermissionError');
+    });
+
+    it('should handle Discogs resource not found errors properly', async () => {
+      const discogsError = new Error('Discogs API Error');
+      discogsError.name = 'DiscogsResourceNotFoundError';
+      (service as any).request.mockRejectedValueOnce(discogsError);
+
+      await expect(
+        service.editCustomFieldValue({
+          username: 'nonexistent',
+          folder_id: 1,
+          release_id: 123,
+          instance_id: 456,
+          field_id: 1,
+          value: 'Mint',
+        }),
+      ).rejects.toThrow('DiscogsResourceNotFoundError');
+    });
+
+    it('should handle validation errors properly', async () => {
+      const discogsError = new Error('Discogs API Error');
+      discogsError.name = 'DiscogsValidationFailedError';
+      (service as any).request.mockRejectedValueOnce(discogsError);
+
+      await expect(
+        service.editCustomFieldValue({
+          username: 'testuser',
+          folder_id: 1,
+          release_id: 123,
+          instance_id: 456,
+          field_id: 1,
+          value: 'Yada Yada',
+        }),
+      ).rejects.toThrow('DiscogsValidationFailedError');
+    });
+  });
 });


### PR DESCRIPTION
### Description

Add a tool for editing the value of a custom field in a release of a user's collection.

### Checklist

- [ ] It's useful if your PR references an issue where it is discussed ahead of time
- [x] Adhere to [semantic messaging](https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716) and prefix your PR title with `feat:`, `fix:`, `chore:`, `docs:`, etc.
- [x] I’ve added tests if needed
- [x] I’ve updated documentation if applicable
- [x] I’ve tested this locally
- [x] Add a changeset (`pnpm changeset`) if necessary

### Tests and linting

- [x] Run the tests with `pnpm test`.
- [x] Run the lint check with `pnpm lint`.
- [x] Run the code formatting (prettier) check with `pnpm format`.