### PR TITLE
feat: add OAuth support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,10 @@
-# Required
+# Authentication Mode (optional)
+# 'token' - Use Personal Access Token only (requires DISCOGS_PERSONAL_ACCESS_TOKEN)
+# 'oauth' - Use OAuth 1.0a flow only
+# 'auto'  - Use token if available, otherwise use OAuth (default)
+DISCOGS_AUTH_MODE=auto
+
+# Personal Access Token (required if DISCOGS_AUTH_MODE=token, optional otherwise)
 DISCOGS_PERSONAL_ACCESS_TOKEN=your_personal_access_token_here
 
 # Optional (defaults to the values below)

--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,6 @@ Thumbs.db
 .cursor/
 
 RELEASE.md
+
+# OAuth token cache
+.discogs_oauth_cache.json

--- a/README.md
+++ b/README.md
@@ -19,6 +19,9 @@ If you just want to get started immediately using this MCP Server with the [Clau
 - [Caveats](#caveats)
 - [Prerequisites](#prerequisites)
 - [Setup](#setup)
+  - [Authentication](#authentication)
+    - [Personal Access Token](#personal-access-token)
+    - [OAuth 1.0a](#oauth-10a)
 - [Running the Server](#running-the-server-locally)
   - [Option 1: Local Development](#option-1-local-development)
   - [Option 2: Docker](#option-2-docker)
@@ -58,14 +61,51 @@ Check out the list of available tools: [TOOLS.md](TOOLS.md)
 
 1. Clone the repository
 2. Create a `.env` file in the root directory based on `.env.example`
-3. Set the following required environment variables in your `.env`:
-   - `DISCOGS_PERSONAL_ACCESS_TOKEN`: Your Discogs personal access token
-
-To get your Discogs personal access token, go to your [Discogs Settings > Developers](https://www.discogs.com/settings/developers) page and find your token or generate a new one. **_DO NOT SHARE YOUR TOKEN_**. OAuth support will be added in a future release.
+3. Configure authentication (see below)
 
 The other environment variables in `.env.example` are optional and have sensible defaults, so you don't need to set them unless you have specific requirements.
 
 - `SERVER_HOST`: The host address to bind the server to (default: `0.0.0.0`). Set to `0.0.0.0` to allow connections from outside the container/machine, or `127.0.0.1` to restrict to localhost only.
+
+### Authentication
+
+The server supports two authentication methods: Personal Access Token and OAuth 1.0a. You can control which method to use via the `DISCOGS_AUTH_MODE` environment variable:
+
+| Mode | Behavior |
+|------|----------|
+| `token` | Use Personal Access Token only (requires `DISCOGS_PERSONAL_ACCESS_TOKEN`) |
+| `oauth` | Use OAuth 1.0a flow only |
+| `auto` (default) | Use token if `DISCOGS_PERSONAL_ACCESS_TOKEN` is set, otherwise use OAuth |
+
+#### Personal Access Token
+
+The simplest authentication method. Get your token from [Discogs Settings > Developers](https://www.discogs.com/settings/developers):
+
+```bash
+DISCOGS_AUTH_MODE=token  # or omit for auto mode
+DISCOGS_PERSONAL_ACCESS_TOKEN=your_token_here
+```
+
+**_DO NOT SHARE YOUR TOKEN_**
+
+#### OAuth 1.0a
+
+OAuth allows users to authorize the application without sharing their credentials. When using OAuth mode:
+
+1. The server will automatically open your browser to the Discogs authorization page
+2. Authorize the application on Discogs
+3. The browser will redirect back to a local callback server
+4. Tokens are encrypted and cached locally (`~/.discogs_oauth_cache.json`) for future sessions
+
+To use OAuth mode explicitly:
+
+```bash
+DISCOGS_AUTH_MODE=oauth
+```
+
+Or simply don't set `DISCOGS_PERSONAL_ACCESS_TOKEN` and auto mode will fall back to OAuth.
+
+**Note for maintainers:** OAuth requires valid consumer credentials. Update the placeholder values in `src/auth/oauth-constants.ts` with your registered application's credentials from [Discogs Developers](https://www.discogs.com/settings/developers).
 
 ## Running the Server Locally
 
@@ -228,7 +268,6 @@ After you Save, in the `Program` tab there should now be an `mcp/discogs` toggle
 
 ## TODO
 
-- OAuth support
 - Missing tools:
   - Inventory uploading
 

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "@modelcontextprotocol/sdk": "^1.12.0",
     "dotenv": "github:cswkim/dotenv",
     "fastmcp": "^3.0.0",
+    "get-port-please": "^3.1.2",
     "zod": "^4.0.5"
   },
   "devDependencies": {
@@ -63,7 +64,6 @@
     "eslint": "^9.24.0",
     "eslint-config-prettier": "^10.1.1",
     "eslint-plugin-prettier": "^5.2.6",
-    "get-port-please": "^3.1.2",
     "prettier": "^3.5.3",
     "shx": "^0.4.0",
     "tsup": "^8.4.0",

--- a/src/auth/index.ts
+++ b/src/auth/index.ts
@@ -1,0 +1,75 @@
+import { config } from '../config.js';
+import { log } from '../utils.js';
+import type { AuthCredentials } from './types.js';
+import { buildOAuthHeader } from './oauth-signer.js';
+import { performOAuthFlow } from './oauth-flow.js';
+import { setAuthCredentials } from './provider.js';
+
+export { setAuthCredentials, getAuthCredentials, ensureAuth } from './provider.js';
+export type { AuthMode, AuthCredentials, OAuthTokenCache } from './types.js';
+
+/**
+ * Creates token-based authentication credentials
+ */
+function createTokenCredentials(token: string): AuthCredentials {
+  return {
+    mode: 'token',
+    getAuthorizationHeader: () => `Discogs token=${token}`,
+  };
+}
+
+/**
+ * Creates OAuth-based authentication credentials
+ */
+function createOAuthCredentials(accessToken: string, accessTokenSecret: string): AuthCredentials {
+  return {
+    mode: 'oauth',
+    getAuthorizationHeader: () => buildOAuthHeader(accessToken, accessTokenSecret),
+  };
+}
+
+/**
+ * Initializes authentication based on the configured mode
+ * Called lazily on first API request via ensureAuth()
+ *
+ * @returns Promise resolving to the authentication credentials
+ */
+export async function initializeAuth(): Promise<AuthCredentials> {
+  const { authMode, personalAccessToken } = config.discogs;
+
+  log.info(`Auth: Mode is "${authMode}"`);
+
+  // Token mode - use personal access token (validated at startup)
+  if (authMode === 'token') {
+    log.info('Auth: Using Personal Access Token');
+    const credentials = createTokenCredentials(personalAccessToken!);
+    setAuthCredentials(credentials);
+    return credentials;
+  }
+
+  // OAuth mode - always use OAuth flow
+  if (authMode === 'oauth') {
+    log.info('Auth: Using OAuth 1.0a');
+    const tokenCache = await performOAuthFlow();
+    const credentials = createOAuthCredentials(
+      tokenCache.accessToken,
+      tokenCache.accessTokenSecret,
+    );
+    setAuthCredentials(credentials);
+    return credentials;
+  }
+
+  // Auto mode - prefer token if available, fall back to OAuth
+  if (personalAccessToken) {
+    log.info('Auth: Auto mode - using Personal Access Token');
+    const credentials = createTokenCredentials(personalAccessToken);
+    setAuthCredentials(credentials);
+    return credentials;
+  }
+
+  log.info('Auth: Auto mode - no token found, using OAuth 1.0a');
+  const tokenCache = await performOAuthFlow();
+  const credentials = createOAuthCredentials(tokenCache.accessToken, tokenCache.accessTokenSecret);
+  setAuthCredentials(credentials);
+  return credentials;
+}

--- a/src/auth/oauth-cache.ts
+++ b/src/auth/oauth-cache.ts
@@ -1,0 +1,107 @@
+import { readFileSync, writeFileSync, unlinkSync, existsSync } from 'fs';
+import { randomBytes, scryptSync, createCipheriv, createDecipheriv } from 'crypto';
+import type { OAuthTokenCache, EncryptedOAuthCache } from './types.js';
+import { OAUTH_CONSUMER_SECRET, OAUTH_CACHE_FILE_PATH } from './oauth-constants.js';
+
+const ALGORITHM = 'aes-256-gcm';
+const KEY_LENGTH = 32;
+const IV_LENGTH = 16;
+const SALT_LENGTH = 32;
+const AUTH_TAG_LENGTH = 16;
+
+/**
+ * Derives an encryption key from the consumer secret using scrypt
+ */
+function deriveKey(salt: Buffer): Buffer {
+  return scryptSync(OAUTH_CONSUMER_SECRET, salt, KEY_LENGTH);
+}
+
+/**
+ * Encrypts token data using AES-256-GCM
+ */
+function encrypt(data: string): EncryptedOAuthCache {
+  const salt = randomBytes(SALT_LENGTH);
+  const key = deriveKey(salt);
+  const iv = randomBytes(IV_LENGTH);
+
+  const cipher = createCipheriv(ALGORITHM, key, iv, { authTagLength: AUTH_TAG_LENGTH });
+  const encrypted = Buffer.concat([cipher.update(data, 'utf8'), cipher.final()]);
+  const authTag = cipher.getAuthTag();
+
+  return {
+    version: 1,
+    iv: iv.toString('hex'),
+    salt: salt.toString('hex'),
+    authTag: authTag.toString('hex'),
+    encryptedData: encrypted.toString('hex'),
+  };
+}
+
+/**
+ * Decrypts token data using AES-256-GCM
+ */
+function decrypt(cache: EncryptedOAuthCache): string {
+  const salt = Buffer.from(cache.salt, 'hex');
+  const key = deriveKey(salt);
+  const iv = Buffer.from(cache.iv, 'hex');
+  const authTag = Buffer.from(cache.authTag, 'hex');
+  const encryptedData = Buffer.from(cache.encryptedData, 'hex');
+
+  const decipher = createDecipheriv(ALGORITHM, key, iv, { authTagLength: AUTH_TAG_LENGTH });
+  decipher.setAuthTag(authTag);
+
+  return Buffer.concat([decipher.update(encryptedData), decipher.final()]).toString('utf8');
+}
+
+/**
+ * Reads cached OAuth tokens from disk
+ * Returns null if cache doesn't exist, is invalid, or decryption fails
+ */
+export function readCachedTokens(): OAuthTokenCache | null {
+  if (!existsSync(OAUTH_CACHE_FILE_PATH)) {
+    return null;
+  }
+
+  try {
+    const fileContent = readFileSync(OAUTH_CACHE_FILE_PATH, 'utf8');
+    const cache: EncryptedOAuthCache = JSON.parse(fileContent);
+
+    // Validate cache structure
+    if (cache.version !== 1 || !cache.iv || !cache.salt || !cache.authTag || !cache.encryptedData) {
+      return null;
+    }
+
+    const decrypted = decrypt(cache);
+    const tokens: OAuthTokenCache = JSON.parse(decrypted);
+
+    // Validate token structure
+    if (!tokens.accessToken || !tokens.accessTokenSecret || !tokens.username) {
+      return null;
+    }
+
+    return tokens;
+  } catch {
+    // Cache is corrupted or tampered with - silently return null
+    // The caller will initiate a new OAuth flow
+    return null;
+  }
+}
+
+/**
+ * Writes OAuth tokens to the encrypted cache file
+ */
+export function writeCachedTokens(tokens: OAuthTokenCache): void {
+  const data = JSON.stringify(tokens);
+  const encrypted = encrypt(data);
+  writeFileSync(OAUTH_CACHE_FILE_PATH, JSON.stringify(encrypted, null, 2), 'utf8');
+}
+
+/**
+ * Deletes the cached OAuth tokens
+ * Called when tokens are revoked or invalid
+ */
+export function deleteCachedTokens(): void {
+  if (existsSync(OAUTH_CACHE_FILE_PATH)) {
+    unlinkSync(OAUTH_CACHE_FILE_PATH);
+  }
+}

--- a/src/auth/oauth-constants.ts
+++ b/src/auth/oauth-constants.ts
@@ -1,0 +1,38 @@
+import { homedir } from 'os';
+import { join } from 'path';
+
+/**
+ * OAuth 1.0a consumer credentials for the Discogs application
+ */
+export const OAUTH_CONSUMER_KEY = 'vzqcJbpNTzntbmKYoxhP';
+export const OAUTH_CONSUMER_SECRET = 'LUYbUNwcgkCBhNbbYAGrYnQbOHvRhKFN';
+
+/**
+ * Discogs OAuth endpoint URLs
+ */
+export const OAUTH_ENDPOINTS = {
+  /** Request token endpoint (step 1 of OAuth flow) */
+  requestToken: 'https://api.discogs.com/oauth/request_token',
+  /** User authorization URL (step 2 - user visits this) */
+  authorize: 'https://www.discogs.com/oauth/authorize',
+  /** Access token endpoint (step 3 of OAuth flow) */
+  accessToken: 'https://api.discogs.com/oauth/access_token',
+  /** Identity verification endpoint */
+  identity: 'https://api.discogs.com/oauth/identity',
+} as const;
+
+/**
+ * Path to the OAuth token cache file
+ * Stored in user's home directory to persist across sessions
+ */
+export const OAUTH_CACHE_FILE_PATH = join(homedir(), '.discogs_oauth_cache.json');
+
+/**
+ * OAuth callback server configuration
+ */
+export const OAUTH_CALLBACK_CONFIG = {
+  /** Timeout for waiting for OAuth callback (5 minutes) */
+  timeoutMs: 5 * 60 * 1000,
+  /** Callback path that Discogs will redirect to */
+  callbackPath: '/oauth/callback',
+} as const;

--- a/src/auth/oauth-flow.ts
+++ b/src/auth/oauth-flow.ts
@@ -1,0 +1,344 @@
+import { createServer, type Server, type IncomingMessage, type ServerResponse } from 'http';
+import { URL } from 'url';
+import { getPort } from 'get-port-please';
+import { config } from '../config.js';
+import { OAuthFlowError } from '../errors.js';
+import { log } from '../utils.js';
+import type { OAuthTokenCache } from './types.js';
+import { OAUTH_ENDPOINTS, OAUTH_CALLBACK_CONFIG } from './oauth-constants.js';
+import {
+  buildRequestTokenHeader,
+  buildAccessTokenHeader,
+  buildOAuthHeader,
+} from './oauth-signer.js';
+import { readCachedTokens, writeCachedTokens, deleteCachedTokens } from './oauth-cache.js';
+
+/**
+ * Parsed OAuth response from Discogs
+ */
+interface OAuthResponse {
+  oauth_token?: string;
+  oauth_token_secret?: string;
+  oauth_verifier?: string;
+}
+
+/**
+ * Discogs identity response
+ */
+interface IdentityResponse {
+  username: string;
+  resource_url: string;
+  consumer_name: string;
+}
+
+/**
+ * Parses URL-encoded OAuth response body
+ */
+function parseOAuthResponse(body: string): OAuthResponse {
+  const params = new URLSearchParams(body);
+  return {
+    oauth_token: params.get('oauth_token') || undefined,
+    oauth_token_secret: params.get('oauth_token_secret') || undefined,
+    oauth_verifier: params.get('oauth_verifier') || undefined,
+  };
+}
+
+/**
+ * Attempts to open a URL in the user's default browser
+ * Falls back to printing the URL if browser opening fails
+ */
+async function openBrowser(url: string): Promise<void> {
+  const { platform } = process;
+
+  try {
+    const { exec } = await import('child_process');
+    const { promisify } = await import('util');
+    const execAsync = promisify(exec);
+
+    if (platform === 'darwin') {
+      await execAsync(`open "${url}"`);
+    } else if (platform === 'win32') {
+      await execAsync(`start "" "${url}"`);
+    } else {
+      // Linux and others
+      await execAsync(`xdg-open "${url}"`);
+    }
+    log.info('Browser opened for authorization');
+  } catch {
+    // Browser opening failed - URL will be printed as fallback
+    log.warn('Could not open browser automatically');
+  }
+}
+
+/**
+ * Step 1: Request a request token from Discogs
+ */
+async function getRequestToken(
+  callbackUrl: string,
+): Promise<{ token: string; tokenSecret: string }> {
+  const authHeader = buildRequestTokenHeader(callbackUrl);
+
+  const response = await fetch(OAUTH_ENDPOINTS.requestToken, {
+    method: 'GET',
+    headers: {
+      'Content-Type': 'application/x-www-form-urlencoded',
+      Authorization: authHeader,
+      'User-Agent': config.discogs.userAgent,
+    },
+  });
+
+  if (!response.ok) {
+    const text = await response.text();
+    throw new OAuthFlowError(`Failed to get request token: ${response.status} ${text}`);
+  }
+
+  const body = await response.text();
+  const parsed = parseOAuthResponse(body);
+
+  if (!parsed.oauth_token || !parsed.oauth_token_secret) {
+    throw new OAuthFlowError('Invalid request token response from Discogs');
+  }
+
+  return {
+    token: parsed.oauth_token,
+    tokenSecret: parsed.oauth_token_secret,
+  };
+}
+
+/**
+ * Step 3: Exchange request token + verifier for access token
+ */
+async function getAccessToken(
+  requestToken: string,
+  requestTokenSecret: string,
+  verifier: string,
+): Promise<{ token: string; tokenSecret: string }> {
+  const authHeader = buildAccessTokenHeader(requestToken, requestTokenSecret, verifier);
+
+  const response = await fetch(OAUTH_ENDPOINTS.accessToken, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/x-www-form-urlencoded',
+      Authorization: authHeader,
+      'User-Agent': config.discogs.userAgent,
+    },
+  });
+
+  if (!response.ok) {
+    const text = await response.text();
+    throw new OAuthFlowError(`Failed to get access token: ${response.status} ${text}`);
+  }
+
+  const body = await response.text();
+  const parsed = parseOAuthResponse(body);
+
+  if (!parsed.oauth_token || !parsed.oauth_token_secret) {
+    throw new OAuthFlowError('Invalid access token response from Discogs');
+  }
+
+  return {
+    token: parsed.oauth_token,
+    tokenSecret: parsed.oauth_token_secret,
+  };
+}
+
+/**
+ * Verifies tokens by calling the identity endpoint
+ */
+async function verifyIdentity(accessToken: string, accessTokenSecret: string): Promise<string> {
+  const authHeader = buildOAuthHeader(accessToken, accessTokenSecret);
+
+  const response = await fetch(OAUTH_ENDPOINTS.identity, {
+    method: 'GET',
+    headers: {
+      Authorization: authHeader,
+      'User-Agent': config.discogs.userAgent,
+    },
+  });
+
+  if (!response.ok) {
+    const text = await response.text();
+    throw new OAuthFlowError(`Failed to verify identity: ${response.status} ${text}`);
+  }
+
+  const identity = (await response.json()) as IdentityResponse;
+  return identity.username;
+}
+
+/**
+ * Creates a temporary HTTP server to receive the OAuth callback
+ */
+function createCallbackServer(port: number): Promise<{ verifier: string }> {
+  return new Promise((resolve, reject) => {
+    // Use object to hold mutable references for cleanup
+    const refs: { timeout: NodeJS.Timeout | null; server: Server | null } = {
+      timeout: null,
+      server: null,
+    };
+
+    const cleanup = () => {
+      if (refs.timeout) clearTimeout(refs.timeout);
+      if (refs.server) refs.server.close();
+    };
+
+    const server = createServer((req: IncomingMessage, res: ServerResponse) => {
+      const url = new URL(req.url || '/', `http://${req.headers.host}`);
+
+      if (url.pathname !== OAUTH_CALLBACK_CONFIG.callbackPath) {
+        res.writeHead(404);
+        res.end('Not Found');
+        return;
+      }
+
+      const verifier = url.searchParams.get('oauth_verifier');
+      const denied = url.searchParams.get('denied');
+
+      if (denied) {
+        res.writeHead(200, { 'Content-Type': 'text/html' });
+        res.end(
+          '<html><body><h1>Authorization Denied</h1><p>You can close this window.</p></body></html>',
+        );
+        cleanup();
+        reject(new OAuthFlowError('User denied OAuth authorization'));
+        return;
+      }
+
+      if (!verifier) {
+        res.writeHead(400, { 'Content-Type': 'text/html' });
+        res.end(
+          '<html><body><h1>Error</h1><p>Missing verifier. Please try again.</p></body></html>',
+        );
+        return;
+      }
+
+      res.writeHead(200, { 'Content-Type': 'text/html' });
+      res.end(
+        '<html><body><h1>Authorization Successful!</h1><p>You can close this window and return to your application.</p></body></html>',
+      );
+
+      cleanup();
+      resolve({ verifier });
+    });
+
+    refs.server = server;
+
+    server.listen(port, 'localhost', () => {
+      log.info(`OAuth: Callback server listening on port ${port}`);
+    });
+
+    server.on('error', (err) => {
+      cleanup();
+      reject(new OAuthFlowError(`Failed to start callback server: ${err.message}`));
+    });
+
+    // Set timeout for the callback
+    refs.timeout = setTimeout(() => {
+      cleanup();
+      reject(
+        new OAuthFlowError('OAuth callback timeout - authorization took too long (5 minutes)'),
+      );
+    }, OAUTH_CALLBACK_CONFIG.timeoutMs);
+  });
+}
+
+/**
+ * Executes the full OAuth 1.0a flow interactively
+ * 1. Get request token
+ * 2. Open browser for user authorization
+ * 3. Wait for callback with verifier
+ * 4. Exchange for access token
+ * 5. Verify identity
+ * 6. Cache tokens
+ */
+export async function performOAuthFlow(): Promise<OAuthTokenCache> {
+  // Check for cached tokens first
+  const cached = readCachedTokens();
+  if (cached) {
+    try {
+      // Verify cached tokens are still valid
+      await verifyIdentity(cached.accessToken, cached.accessTokenSecret);
+      log.info(`OAuth: Using cached credentials for user "${cached.username}"`);
+      return cached;
+    } catch {
+      // Cached tokens are invalid, delete and re-authenticate
+      log.warn('OAuth: Cached tokens are invalid, re-authenticating...');
+      deleteCachedTokens();
+    }
+  }
+
+  log.info('OAuth: Starting interactive authorization flow...');
+
+  // Get a dynamic port for the callback server
+  const port = await getPort({ portRange: [49152, 65535] });
+  const callbackUrl = `http://localhost:${port}${OAUTH_CALLBACK_CONFIG.callbackPath}`;
+
+  // Step 1: Get request token
+  log.info('OAuth: Requesting temporary credentials...');
+  const requestTokens = await getRequestToken(callbackUrl);
+
+  // Build authorization URL
+  const authUrl = `${OAUTH_ENDPOINTS.authorize}?oauth_token=${requestTokens.token}`;
+
+  // Start callback server before opening browser
+  const serverPromise = createCallbackServer(port);
+
+  // Step 2: Open browser for authorization
+  log.info('OAuth: Opening browser for authorization...');
+  log.info(`OAuth: If browser doesn't open, visit: ${authUrl}`);
+  await openBrowser(authUrl);
+
+  // Wait for callback
+  const { verifier } = await serverPromise;
+
+  // Step 3: Exchange for access token
+  log.info('OAuth: Exchanging for access token...');
+  const accessTokens = await getAccessToken(
+    requestTokens.token,
+    requestTokens.tokenSecret,
+    verifier,
+  );
+
+  // Step 4: Verify identity
+  log.info('OAuth: Verifying identity...');
+  const username = await verifyIdentity(accessTokens.token, accessTokens.tokenSecret);
+
+  // Step 5: Cache tokens
+  const tokenCache: OAuthTokenCache = {
+    accessToken: accessTokens.token,
+    accessTokenSecret: accessTokens.tokenSecret,
+    username,
+    obtainedAt: Date.now(),
+  };
+
+  writeCachedTokens(tokenCache);
+  log.info(`OAuth: Successfully authenticated as "${username}"`);
+
+  return tokenCache;
+}
+
+/**
+ * Verifies existing cached tokens are still valid
+ * Returns the cached tokens if valid, null otherwise
+ */
+export async function verifyCachedTokens(): Promise<OAuthTokenCache | null> {
+  const cached = readCachedTokens();
+  if (!cached) {
+    return null;
+  }
+
+  try {
+    await verifyIdentity(cached.accessToken, cached.accessTokenSecret);
+    return cached;
+  } catch {
+    deleteCachedTokens();
+    return null;
+  }
+}
+
+/**
+ * Invalidates the current OAuth session by deleting cached tokens
+ */
+export function invalidateOAuthSession(): void {
+  deleteCachedTokens();
+  log.info('OAuth: Session invalidated, tokens deleted');
+}

--- a/src/auth/oauth-signer.ts
+++ b/src/auth/oauth-signer.ts
@@ -1,0 +1,109 @@
+import { randomBytes } from 'crypto';
+import { OAUTH_CONSUMER_KEY, OAUTH_CONSUMER_SECRET } from './oauth-constants.js';
+
+/**
+ * Generates a random nonce for OAuth requests
+ */
+function generateNonce(): string {
+  return randomBytes(16).toString('hex');
+}
+
+/**
+ * Gets the current timestamp in seconds
+ */
+function getTimestamp(): string {
+  return Math.floor(Date.now() / 1000).toString();
+}
+
+/**
+ * Encodes a value for OAuth (RFC 3986)
+ */
+function oauthEncode(value: string): string {
+  return encodeURIComponent(value).replace(
+    /[!'()*]/g,
+    (c) => `%${c.charCodeAt(0).toString(16).toUpperCase()}`,
+  );
+}
+
+/**
+ * Builds the OAuth Authorization header parameters as an object
+ */
+function buildOAuthParams(additionalParams: Record<string, string> = {}): Record<string, string> {
+  return {
+    oauth_consumer_key: OAUTH_CONSUMER_KEY,
+    oauth_nonce: generateNonce(),
+    oauth_signature_method: 'PLAINTEXT',
+    oauth_timestamp: getTimestamp(),
+    oauth_version: '1.0',
+    ...additionalParams,
+  };
+}
+
+/**
+ * Formats OAuth parameters into an Authorization header string
+ */
+function formatAuthorizationHeader(params: Record<string, string>): string {
+  const paramString = Object.entries(params)
+    .map(([key, value]) => `${oauthEncode(key)}="${oauthEncode(value)}"`)
+    .join(', ');
+  return `OAuth ${paramString}`;
+}
+
+/**
+ * Generates the PLAINTEXT signature for OAuth 1.0a
+ * Format: consumer_secret&token_secret (token_secret may be empty)
+ */
+function generatePlaintextSignature(tokenSecret: string = ''): string {
+  return `${oauthEncode(OAUTH_CONSUMER_SECRET)}&${oauthEncode(tokenSecret)}`;
+}
+
+/**
+ * Builds the OAuth Authorization header for authenticated API requests
+ * Used after obtaining access tokens
+ *
+ * @param accessToken - The OAuth access token
+ * @param accessTokenSecret - The OAuth access token secret
+ * @returns The Authorization header value
+ */
+export function buildOAuthHeader(accessToken: string, accessTokenSecret: string): string {
+  const params = buildOAuthParams({
+    oauth_token: accessToken,
+    oauth_signature: generatePlaintextSignature(accessTokenSecret),
+  });
+  return formatAuthorizationHeader(params);
+}
+
+/**
+ * Builds the OAuth Authorization header for requesting a request token (step 1)
+ *
+ * @param callbackUrl - The callback URL for OAuth (where Discogs redirects after auth)
+ * @returns The Authorization header value
+ */
+export function buildRequestTokenHeader(callbackUrl: string): string {
+  const params = buildOAuthParams({
+    oauth_callback: callbackUrl,
+    oauth_signature: generatePlaintextSignature(),
+  });
+  return formatAuthorizationHeader(params);
+}
+
+/**
+ * Builds the OAuth Authorization header for exchanging request token for access token (step 3)
+ *
+ * @param requestToken - The request token obtained in step 1
+ * @param requestTokenSecret - The request token secret obtained in step 1
+ * @param verifier - The oauth_verifier from the callback
+ * @returns The Authorization header value
+ */
+export function buildAccessTokenHeader(
+  requestToken: string,
+  requestTokenSecret: string,
+  verifier: string,
+): string {
+  const params = buildOAuthParams({
+    oauth_token: requestToken,
+    oauth_verifier: verifier,
+    oauth_signature: generatePlaintextSignature(requestTokenSecret),
+  });
+  return formatAuthorizationHeader(params);
+}

--- a/src/auth/provider.ts
+++ b/src/auth/provider.ts
@@ -1,0 +1,70 @@
+import type { AuthCredentials } from './types.js';
+
+/**
+ * Singleton storage for authentication credentials
+ * Initialized lazily on first API request
+ */
+let authCredentials: AuthCredentials | null = null;
+
+/**
+ * Promise for in-progress initialization to prevent concurrent init attempts
+ */
+let initPromise: Promise<AuthCredentials> | null = null;
+
+/**
+ * Sets the authentication credentials for the application
+ *
+ * @param credentials - The resolved authentication credentials
+ */
+export function setAuthCredentials(credentials: AuthCredentials): void {
+  authCredentials = credentials;
+}
+
+/**
+ * Gets the current authentication credentials
+ * Used by services to build API request headers
+ *
+ * @returns The authentication credentials
+ * @throws Error if credentials haven't been set
+ */
+export function getAuthCredentials(): AuthCredentials {
+  if (!authCredentials) {
+    throw new Error('Authentication credentials not initialized. Call ensureAuth() first.');
+  }
+  return authCredentials;
+}
+
+/**
+ * Checks if authentication credentials have been set
+ */
+export function hasAuthCredentials(): boolean {
+  return authCredentials !== null;
+}
+
+/**
+ * Ensures authentication is initialized before making API requests
+ * This is idempotent - subsequent calls return immediately if already initialized
+ *
+ * @returns Promise resolving to the authentication credentials
+ */
+export async function ensureAuth(): Promise<AuthCredentials> {
+  // Already initialized
+  if (authCredentials) {
+    return authCredentials;
+  }
+
+  // Initialization in progress - wait for it
+  if (initPromise) {
+    return initPromise;
+  }
+
+  // Start initialization - dynamic import to avoid circular dependency
+  const { initializeAuth } = await import('./index.js');
+  initPromise = initializeAuth();
+
+  try {
+    return await initPromise;
+  } finally {
+    initPromise = null;
+  }
+}

--- a/src/auth/types.ts
+++ b/src/auth/types.ts
@@ -1,0 +1,48 @@
+/**
+ * Authentication mode for the Discogs API
+ * - 'token': Use Personal Access Token (existing method)
+ * - 'oauth': Use OAuth 1.0a flow
+ * - 'auto': Auto-detect (use token if available, else OAuth)
+ */
+export type AuthMode = 'token' | 'oauth' | 'auto';
+
+/**
+ * Interface for authentication credentials
+ * Provides a unified way to get authorization headers regardless of auth method
+ */
+export interface AuthCredentials {
+  /** The authentication mode being used */
+  mode: AuthMode;
+  /** Returns the Authorization header value for API requests */
+  getAuthorizationHeader(): string;
+}
+
+/**
+ * OAuth token cache structure for storing access tokens
+ */
+export interface OAuthTokenCache {
+  /** OAuth access token */
+  accessToken: string;
+  /** OAuth access token secret */
+  accessTokenSecret: string;
+  /** Discogs username associated with the token */
+  username: string;
+  /** Timestamp when the token was obtained */
+  obtainedAt: number;
+}
+
+/**
+ * Encrypted OAuth cache file structure
+ */
+export interface EncryptedOAuthCache {
+  /** Version of the cache format */
+  version: 1;
+  /** Initialization vector (hex encoded) */
+  iv: string;
+  /** Salt used for key derivation (hex encoded) */
+  salt: string;
+  /** Authentication tag (hex encoded) */
+  authTag: string;
+  /** Encrypted token data (hex encoded) */
+  encryptedData: string;
+}

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -11,6 +11,13 @@ export class DiscogsError extends Error {
   }
 }
 
+export class OAuthFlowError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = new.target.name;
+  }
+}
+
 export class DiscogsAuthenticationError extends DiscogsError {
   constructor(message = 'Authentication failed') {
     super(message, 401, { message });

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,7 +11,7 @@ function assertTransportType(transportType: string): transportType is ServerTran
   return transportType === 'stdio' || transportType === 'stream';
 }
 
-try {
+async function main(): Promise<void> {
   validateConfig();
 
   // Grab the transport type from the command line
@@ -44,10 +44,12 @@ try {
   }
 
   log.info(`${config.server.name} started with transport type: ${transportType}`);
-} catch (error: unknown) {
+}
+
+main().catch((error: unknown) => {
   log.error(`Failed to run the ${config.server.name}: `, error);
   process.exit(1);
-}
+});
 
 // Handle process termination gracefully
 process.on('SIGINT', () => {

--- a/tests/auth/index.test.ts
+++ b/tests/auth/index.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+
+describe('Auth Module', () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    vi.resetAllMocks();
+  });
+
+  describe('initializeAuth', () => {
+    beforeEach(() => {
+      vi.mock('../../src/utils.js', () => ({
+        log: {
+          info: vi.fn(),
+          warn: vi.fn(),
+          error: vi.fn(),
+        },
+      }));
+
+      vi.mock('../../src/auth/oauth-flow.js', () => ({
+        performOAuthFlow: vi.fn(() =>
+          Promise.resolve({
+            accessToken: 'oauth-access-token',
+            accessTokenSecret: 'oauth-access-secret',
+            username: 'oauthuser',
+            obtainedAt: Date.now(),
+          }),
+        ),
+      }));
+
+      vi.mock('../../src/auth/oauth-signer.js', () => ({
+        buildOAuthHeader: vi.fn(() => 'OAuth mock-header'),
+      }));
+
+      vi.mock('../../src/auth/provider.js', () => ({
+        setAuthCredentials: vi.fn(),
+        getAuthCredentials: vi.fn(),
+        ensureAuth: vi.fn(),
+      }));
+    });
+
+    it('should use token auth when mode is "token" and token is available', async () => {
+      vi.doMock('../../src/config.js', () => ({
+        config: {
+          discogs: {
+            authMode: 'token',
+            personalAccessToken: 'my-token',
+          },
+        },
+      }));
+
+      const { initializeAuth } = await import('../../src/auth/index.js');
+      const { setAuthCredentials } = await import('../../src/auth/provider.js');
+
+      const result = await initializeAuth();
+
+      expect(result.mode).toBe('token');
+      expect(result.getAuthorizationHeader()).toBe('Discogs token=my-token');
+      expect(setAuthCredentials).toHaveBeenCalled();
+    });
+
+    it('should use OAuth when mode is "oauth"', async () => {
+      vi.doMock('../../src/config.js', () => ({
+        config: {
+          discogs: {
+            authMode: 'oauth',
+            personalAccessToken: undefined,
+          },
+        },
+      }));
+
+      const { initializeAuth } = await import('../../src/auth/index.js');
+      const { performOAuthFlow } = await import('../../src/auth/oauth-flow.js');
+
+      const result = await initializeAuth();
+
+      expect(result.mode).toBe('oauth');
+      expect(performOAuthFlow).toHaveBeenCalled();
+    });
+
+    it('should use token in auto mode when token is available', async () => {
+      vi.doMock('../../src/config.js', () => ({
+        config: {
+          discogs: {
+            authMode: 'auto',
+            personalAccessToken: 'auto-token',
+          },
+        },
+      }));
+
+      const { initializeAuth } = await import('../../src/auth/index.js');
+      const { performOAuthFlow } = await import('../../src/auth/oauth-flow.js');
+
+      const result = await initializeAuth();
+
+      expect(result.mode).toBe('token');
+      expect(result.getAuthorizationHeader()).toBe('Discogs token=auto-token');
+      expect(performOAuthFlow).not.toHaveBeenCalled();
+    });
+
+    it('should use OAuth in auto mode when no token is available', async () => {
+      vi.doMock('../../src/config.js', () => ({
+        config: {
+          discogs: {
+            authMode: 'auto',
+            personalAccessToken: undefined,
+          },
+        },
+      }));
+
+      const { initializeAuth } = await import('../../src/auth/index.js');
+      const { performOAuthFlow } = await import('../../src/auth/oauth-flow.js');
+
+      const result = await initializeAuth();
+
+      expect(result.mode).toBe('oauth');
+      expect(performOAuthFlow).toHaveBeenCalled();
+    });
+  });
+});

--- a/tests/auth/oauth-cache.test.ts
+++ b/tests/auth/oauth-cache.test.ts
@@ -1,0 +1,212 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+import { existsSync, readFileSync, writeFileSync, unlinkSync } from 'fs';
+import type { OAuthTokenCache, EncryptedOAuthCache } from '../../src/auth/types.js';
+
+// Mock the oauth-constants module
+vi.mock('../../src/auth/oauth-constants.js', () => ({
+  OAUTH_CONSUMER_SECRET: 'test-consumer-secret-for-encryption',
+  OAUTH_CACHE_FILE_PATH: '/tmp/test-oauth-cache.json',
+}));
+
+// Mock fs module
+vi.mock('fs', () => ({
+  existsSync: vi.fn(),
+  readFileSync: vi.fn(),
+  writeFileSync: vi.fn(),
+  unlinkSync: vi.fn(),
+}));
+
+describe('OAuth Cache', () => {
+  let readCachedTokens: () => OAuthTokenCache | null;
+  let writeCachedTokens: (tokens: OAuthTokenCache) => void;
+  let deleteCachedTokens: () => void;
+
+  beforeEach(async () => {
+    vi.resetModules();
+    vi.resetAllMocks();
+
+    // Import fresh module for each test
+    const cacheModule = await import('../../src/auth/oauth-cache.js');
+    readCachedTokens = cacheModule.readCachedTokens;
+    writeCachedTokens = cacheModule.writeCachedTokens;
+    deleteCachedTokens = cacheModule.deleteCachedTokens;
+  });
+
+  afterEach(() => {
+    vi.resetAllMocks();
+  });
+
+  describe('readCachedTokens', () => {
+    it('should return null if cache file does not exist', () => {
+      vi.mocked(existsSync).mockReturnValue(false);
+
+      const result = readCachedTokens();
+
+      expect(result).toBeNull();
+      expect(existsSync).toHaveBeenCalled();
+    });
+
+    it('should return null if cache file is invalid JSON', () => {
+      vi.mocked(existsSync).mockReturnValue(true);
+      vi.mocked(readFileSync).mockReturnValue('invalid json');
+
+      const result = readCachedTokens();
+
+      expect(result).toBeNull();
+    });
+
+    it('should return null if cache structure is invalid', () => {
+      vi.mocked(existsSync).mockReturnValue(true);
+      vi.mocked(readFileSync).mockReturnValue(
+        JSON.stringify({
+          version: 2, // Wrong version
+          iv: 'abc',
+          salt: 'def',
+          authTag: 'ghi',
+          encryptedData: 'jkl',
+        }),
+      );
+
+      const result = readCachedTokens();
+
+      expect(result).toBeNull();
+    });
+
+    it('should return null if cache is missing required fields', () => {
+      vi.mocked(existsSync).mockReturnValue(true);
+      vi.mocked(readFileSync).mockReturnValue(
+        JSON.stringify({
+          version: 1,
+          iv: 'abc',
+          // Missing salt, authTag, encryptedData
+        }),
+      );
+
+      const result = readCachedTokens();
+
+      expect(result).toBeNull();
+    });
+
+    it('should return null if decryption fails', () => {
+      vi.mocked(existsSync).mockReturnValue(true);
+      vi.mocked(readFileSync).mockReturnValue(
+        JSON.stringify({
+          version: 1,
+          iv: 'invalidiv',
+          salt: 'invalidsalt',
+          authTag: 'invalidtag',
+          encryptedData: 'invaliddata',
+        }),
+      );
+
+      const result = readCachedTokens();
+
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('writeCachedTokens', () => {
+    it('should write encrypted tokens to file', () => {
+      const tokens: OAuthTokenCache = {
+        accessToken: 'test-access-token',
+        accessTokenSecret: 'test-access-secret',
+        username: 'testuser',
+        obtainedAt: Date.now(),
+      };
+
+      writeCachedTokens(tokens);
+
+      expect(writeFileSync).toHaveBeenCalledTimes(1);
+      const [filePath, content] = vi.mocked(writeFileSync).mock.calls[0];
+
+      expect(filePath).toBe('/tmp/test-oauth-cache.json');
+
+      // Parse the written content
+      const encrypted: EncryptedOAuthCache = JSON.parse(content as string);
+      expect(encrypted.version).toBe(1);
+      expect(encrypted.iv).toBeDefined();
+      expect(encrypted.salt).toBeDefined();
+      expect(encrypted.authTag).toBeDefined();
+      expect(encrypted.encryptedData).toBeDefined();
+
+      // Verify hex encoding
+      expect(encrypted.iv).toMatch(/^[0-9a-f]+$/i);
+      expect(encrypted.salt).toMatch(/^[0-9a-f]+$/i);
+      expect(encrypted.authTag).toMatch(/^[0-9a-f]+$/i);
+      expect(encrypted.encryptedData).toMatch(/^[0-9a-f]+$/i);
+    });
+  });
+
+  describe('deleteCachedTokens', () => {
+    it('should delete cache file if it exists', () => {
+      vi.mocked(existsSync).mockReturnValue(true);
+
+      deleteCachedTokens();
+
+      expect(unlinkSync).toHaveBeenCalledWith('/tmp/test-oauth-cache.json');
+    });
+
+    it('should not throw if cache file does not exist', () => {
+      vi.mocked(existsSync).mockReturnValue(false);
+
+      expect(() => deleteCachedTokens()).not.toThrow();
+      expect(unlinkSync).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('round-trip encryption/decryption', () => {
+    it('should encrypt and decrypt tokens correctly', () => {
+      const originalTokens: OAuthTokenCache = {
+        accessToken: 'my-access-token',
+        accessTokenSecret: 'my-access-secret',
+        username: 'myuser',
+        obtainedAt: 1705320000000,
+      };
+
+      // Capture what gets written
+      let writtenContent: string = '';
+      vi.mocked(writeFileSync).mockImplementation((_path, content) => {
+        writtenContent = content as string;
+      });
+
+      writeCachedTokens(originalTokens);
+
+      // Now mock readFileSync to return what was written
+      vi.mocked(existsSync).mockReturnValue(true);
+      vi.mocked(readFileSync).mockReturnValue(writtenContent);
+
+      const readTokens = readCachedTokens();
+
+      expect(readTokens).not.toBeNull();
+      expect(readTokens?.accessToken).toBe(originalTokens.accessToken);
+      expect(readTokens?.accessTokenSecret).toBe(originalTokens.accessTokenSecret);
+      expect(readTokens?.username).toBe(originalTokens.username);
+      expect(readTokens?.obtainedAt).toBe(originalTokens.obtainedAt);
+    });
+
+    it('should handle special characters in tokens', () => {
+      const originalTokens: OAuthTokenCache = {
+        accessToken: 'token+with=special&chars/and"quotes',
+        accessTokenSecret: 'secret\nwith\ttabs',
+        username: 'user@example.com',
+        obtainedAt: Date.now(),
+      };
+
+      let writtenContent: string = '';
+      vi.mocked(writeFileSync).mockImplementation((_path, content) => {
+        writtenContent = content as string;
+      });
+
+      writeCachedTokens(originalTokens);
+
+      vi.mocked(existsSync).mockReturnValue(true);
+      vi.mocked(readFileSync).mockReturnValue(writtenContent);
+
+      const readTokens = readCachedTokens();
+
+      expect(readTokens?.accessToken).toBe(originalTokens.accessToken);
+      expect(readTokens?.accessTokenSecret).toBe(originalTokens.accessTokenSecret);
+      expect(readTokens?.username).toBe(originalTokens.username);
+    });
+  });
+});

--- a/tests/auth/oauth-flow.test.ts
+++ b/tests/auth/oauth-flow.test.ts
@@ -1,0 +1,247 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+import type { OAuthTokenCache } from '../../src/auth/types.js';
+
+// Mock dependencies before importing the module
+vi.mock('../../src/config.js', () => ({
+  config: {
+    discogs: {
+      userAgent: 'TestAgent/1.0',
+    },
+  },
+}));
+
+vi.mock('../../src/utils.js', () => ({
+  log: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+vi.mock('../../src/auth/oauth-constants.js', () => ({
+  OAUTH_ENDPOINTS: {
+    requestToken: 'https://api.discogs.com/oauth/request_token',
+    authorize: 'https://www.discogs.com/oauth/authorize',
+    accessToken: 'https://api.discogs.com/oauth/access_token',
+    identity: 'https://api.discogs.com/oauth/identity',
+  },
+  OAUTH_CALLBACK_CONFIG: {
+    timeoutMs: 1000, // Short timeout for tests
+    callbackPath: '/oauth/callback',
+  },
+}));
+
+vi.mock('../../src/auth/oauth-signer.js', () => ({
+  buildRequestTokenHeader: vi.fn(() => 'OAuth request-token-header'),
+  buildAccessTokenHeader: vi.fn(() => 'OAuth access-token-header'),
+  buildOAuthHeader: vi.fn(() => 'OAuth auth-header'),
+}));
+
+vi.mock('../../src/auth/oauth-cache.js', () => ({
+  readCachedTokens: vi.fn(),
+  writeCachedTokens: vi.fn(),
+  deleteCachedTokens: vi.fn(),
+}));
+
+vi.mock('get-port-please', () => ({
+  getPort: vi.fn(() => Promise.resolve(54321)),
+}));
+
+// Mock child_process for browser opening
+vi.mock('child_process', () => ({
+  exec: vi.fn((_cmd, callback) => callback?.(null, '', '')),
+}));
+
+vi.mock('util', () => ({
+  promisify: vi.fn((fn) => fn),
+}));
+
+describe('OAuth Flow', () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+  let performOAuthFlow: () => Promise<OAuthTokenCache>;
+  let verifyCachedTokens: () => Promise<OAuthTokenCache | null>;
+  let invalidateOAuthSession: () => void;
+
+  beforeEach(async () => {
+    vi.resetModules();
+
+    // Setup fetch mock
+    fetchMock = vi.fn();
+    global.fetch = fetchMock as typeof fetch;
+
+    // Import fresh module
+    const flowModule = await import('../../src/auth/oauth-flow.js');
+    performOAuthFlow = flowModule.performOAuthFlow;
+    verifyCachedTokens = flowModule.verifyCachedTokens;
+    invalidateOAuthSession = flowModule.invalidateOAuthSession;
+  });
+
+  afterEach(() => {
+    vi.resetAllMocks();
+  });
+
+  describe('performOAuthFlow', () => {
+    it('should return cached tokens if they are valid', async () => {
+      const cachedTokens: OAuthTokenCache = {
+        accessToken: 'cached-access-token',
+        accessTokenSecret: 'cached-access-secret',
+        username: 'cacheduser',
+        obtainedAt: Date.now(),
+      };
+
+      const { readCachedTokens } = await import('../../src/auth/oauth-cache.js');
+      vi.mocked(readCachedTokens).mockReturnValue(cachedTokens);
+
+      // Mock identity verification success
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ username: 'cacheduser' }),
+      });
+
+      const result = await performOAuthFlow();
+
+      expect(result).toEqual(cachedTokens);
+      expect(fetchMock).toHaveBeenCalledTimes(1); // Only identity check
+    });
+
+    it('should delete cache when cached tokens are invalid', async () => {
+      const cachedTokens: OAuthTokenCache = {
+        accessToken: 'invalid-token',
+        accessTokenSecret: 'invalid-secret',
+        username: 'olduser',
+        obtainedAt: Date.now(),
+      };
+
+      const { readCachedTokens, deleteCachedTokens } =
+        await import('../../src/auth/oauth-cache.js');
+
+      // First call returns cached tokens, second call (after deletion) returns null
+      vi.mocked(readCachedTokens).mockReturnValueOnce(cachedTokens).mockReturnValueOnce(null);
+
+      // Mock identity verification failure (token invalid)
+      fetchMock.mockResolvedValueOnce({
+        ok: false,
+        status: 401,
+        text: () => Promise.resolve('Unauthorized'),
+      });
+
+      // Use verifyCachedTokens instead which doesn't start the full flow
+      const result = await verifyCachedTokens();
+
+      expect(result).toBeNull();
+      expect(deleteCachedTokens).toHaveBeenCalled();
+    });
+  });
+
+  describe('verifyCachedTokens', () => {
+    it('should return null if no cached tokens exist', async () => {
+      const { readCachedTokens } = await import('../../src/auth/oauth-cache.js');
+      vi.mocked(readCachedTokens).mockReturnValue(null);
+
+      const result = await verifyCachedTokens();
+
+      expect(result).toBeNull();
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('should return tokens if they are valid', async () => {
+      const cachedTokens: OAuthTokenCache = {
+        accessToken: 'valid-token',
+        accessTokenSecret: 'valid-secret',
+        username: 'validuser',
+        obtainedAt: Date.now(),
+      };
+
+      const { readCachedTokens } = await import('../../src/auth/oauth-cache.js');
+      vi.mocked(readCachedTokens).mockReturnValue(cachedTokens);
+
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ username: 'validuser' }),
+      });
+
+      const result = await verifyCachedTokens();
+
+      expect(result).toEqual(cachedTokens);
+    });
+
+    it('should delete cache and return null if tokens are invalid', async () => {
+      const cachedTokens: OAuthTokenCache = {
+        accessToken: 'expired-token',
+        accessTokenSecret: 'expired-secret',
+        username: 'expireduser',
+        obtainedAt: Date.now(),
+      };
+
+      const { readCachedTokens, deleteCachedTokens } =
+        await import('../../src/auth/oauth-cache.js');
+      vi.mocked(readCachedTokens).mockReturnValue(cachedTokens);
+
+      fetchMock.mockResolvedValueOnce({
+        ok: false,
+        status: 401,
+        text: () => Promise.resolve('Token expired'),
+      });
+
+      const result = await verifyCachedTokens();
+
+      expect(result).toBeNull();
+      expect(deleteCachedTokens).toHaveBeenCalled();
+    });
+  });
+
+  describe('invalidateOAuthSession', () => {
+    it('should delete cached tokens', async () => {
+      const { deleteCachedTokens } = await import('../../src/auth/oauth-cache.js');
+
+      invalidateOAuthSession();
+
+      expect(deleteCachedTokens).toHaveBeenCalled();
+    });
+  });
+});
+
+describe('OAuth Flow HTTP Requests', () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.resetModules();
+    fetchMock = vi.fn();
+    global.fetch = fetchMock as typeof fetch;
+  });
+
+  afterEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('should verify identity with correct headers when using cached tokens', async () => {
+    const cachedTokens: OAuthTokenCache = {
+      accessToken: 'test-token',
+      accessTokenSecret: 'test-secret',
+      username: 'testuser',
+      obtainedAt: Date.now(),
+    };
+
+    const { readCachedTokens } = await import('../../src/auth/oauth-cache.js');
+    vi.mocked(readCachedTokens).mockReturnValue(cachedTokens);
+
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({ username: 'testuser' }),
+    });
+
+    const flowModule = await import('../../src/auth/oauth-flow.js');
+    await flowModule.performOAuthFlow();
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://api.discogs.com/oauth/identity',
+      expect.objectContaining({
+        method: 'GET',
+        headers: expect.objectContaining({
+          Authorization: 'OAuth auth-header',
+          'User-Agent': 'TestAgent/1.0',
+        }),
+      }),
+    );
+  });
+});

--- a/tests/auth/oauth-signer.test.ts
+++ b/tests/auth/oauth-signer.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import {
+  buildOAuthHeader,
+  buildRequestTokenHeader,
+  buildAccessTokenHeader,
+} from '../../src/auth/oauth-signer.js';
+
+// Mock the oauth-constants module
+vi.mock('../../src/auth/oauth-constants.js', () => ({
+  OAUTH_CONSUMER_KEY: 'test-consumer-key',
+  OAUTH_CONSUMER_SECRET: 'test-consumer-secret',
+}));
+
+// Mock crypto.randomBytes to return predictable values for testing
+vi.mock('crypto', async () => {
+  const actual = await vi.importActual('crypto');
+  return {
+    ...actual,
+    randomBytes: vi.fn(() => Buffer.from('1234567890abcdef1234567890abcdef', 'hex')),
+  };
+});
+
+describe('OAuth Signer', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2024-01-15T12:00:00Z'));
+  });
+
+  describe('buildOAuthHeader', () => {
+    it('should build a valid OAuth header for authenticated requests', () => {
+      const header = buildOAuthHeader('access-token', 'access-token-secret');
+
+      expect(header).toMatch(/^OAuth /);
+      expect(header).toContain('oauth_consumer_key="test-consumer-key"');
+      expect(header).toContain('oauth_token="access-token"');
+      expect(header).toContain('oauth_signature_method="PLAINTEXT"');
+      expect(header).toContain('oauth_version="1.0"');
+      // PLAINTEXT signature: consumer_secret&token_secret
+      expect(header).toContain('oauth_signature="test-consumer-secret%26access-token-secret"');
+      expect(header).toContain('oauth_timestamp=');
+      expect(header).toContain('oauth_nonce=');
+    });
+
+    it('should include timestamp in seconds', () => {
+      const header = buildOAuthHeader('token', 'secret');
+      // 2024-01-15T12:00:00Z = 1705320000 seconds
+      expect(header).toContain('oauth_timestamp="1705320000"');
+    });
+
+    it('should URL-encode special characters in tokens', () => {
+      const header = buildOAuthHeader('token+with=special&chars', 'secret/with spaces');
+
+      expect(header).toContain('oauth_token="token%2Bwith%3Dspecial%26chars"');
+      // The signature is double-encoded (once in signature generation, once in header formatting)
+      // So / becomes %2F then %252F, and space becomes %20 then %2520
+      expect(header).toContain('oauth_signature=');
+    });
+  });
+
+  describe('buildRequestTokenHeader', () => {
+    it('should build a valid OAuth header for request token', () => {
+      const header = buildRequestTokenHeader('http://localhost:8080/callback');
+
+      expect(header).toMatch(/^OAuth /);
+      expect(header).toContain('oauth_consumer_key="test-consumer-key"');
+      expect(header).toContain('oauth_callback="http%3A%2F%2Flocalhost%3A8080%2Fcallback"');
+      expect(header).toContain('oauth_signature_method="PLAINTEXT"');
+      expect(header).toContain('oauth_version="1.0"');
+      // PLAINTEXT signature with empty token secret: consumer_secret&
+      expect(header).toContain('oauth_signature="test-consumer-secret%26"');
+      expect(header).not.toContain('oauth_token=');
+    });
+
+    it('should URL-encode the callback URL', () => {
+      const header = buildRequestTokenHeader('http://localhost:8080/oauth/callback?state=123');
+
+      expect(header).toContain(
+        'oauth_callback="http%3A%2F%2Flocalhost%3A8080%2Foauth%2Fcallback%3Fstate%3D123"',
+      );
+    });
+  });
+
+  describe('buildAccessTokenHeader', () => {
+    it('should build a valid OAuth header for access token exchange', () => {
+      const header = buildAccessTokenHeader('request-token', 'request-token-secret', 'verifier123');
+
+      expect(header).toMatch(/^OAuth /);
+      expect(header).toContain('oauth_consumer_key="test-consumer-key"');
+      expect(header).toContain('oauth_token="request-token"');
+      expect(header).toContain('oauth_verifier="verifier123"');
+      expect(header).toContain('oauth_signature_method="PLAINTEXT"');
+      expect(header).toContain('oauth_version="1.0"');
+      // PLAINTEXT signature: consumer_secret&request_token_secret
+      expect(header).toContain('oauth_signature="test-consumer-secret%26request-token-secret"');
+    });
+
+    it('should include all required OAuth parameters', () => {
+      const header = buildAccessTokenHeader('token', 'secret', 'verifier');
+
+      const requiredParams = [
+        'oauth_consumer_key',
+        'oauth_token',
+        'oauth_verifier',
+        'oauth_signature_method',
+        'oauth_signature',
+        'oauth_timestamp',
+        'oauth_nonce',
+        'oauth_version',
+      ];
+
+      for (const param of requiredParams) {
+        expect(header).toContain(param);
+      }
+    });
+  });
+
+  describe('OAuth header format', () => {
+    it('should format parameters as key="value" pairs', () => {
+      const header = buildOAuthHeader('token', 'secret');
+
+      // Check the format: OAuth key="value", key="value", ...
+      const match = header.match(/^OAuth (.+)$/);
+      expect(match).not.toBeNull();
+
+      const params = match![1].split(', ');
+      for (const param of params) {
+        expect(param).toMatch(/^[a-z_]+=".+"$/);
+      }
+    });
+
+    it('should generate unique nonces for each call', async () => {
+      // Reset the mock to return different values
+      const crypto = await import('crypto');
+      let callCount = 0;
+      vi.mocked(crypto.randomBytes).mockImplementation(() => {
+        callCount++;
+        return Buffer.from(`${callCount}234567890abcdef1234567890abcdef`.slice(0, 32), 'hex');
+      });
+
+      const header1 = buildOAuthHeader('token', 'secret');
+      const header2 = buildOAuthHeader('token', 'secret');
+
+      const nonce1 = header1.match(/oauth_nonce="([^"]+)"/)?.[1];
+      const nonce2 = header2.match(/oauth_nonce="([^"]+)"/)?.[1];
+
+      expect(nonce1).not.toBe(nonce2);
+    });
+  });
+});

--- a/tests/auth/provider.test.ts
+++ b/tests/auth/provider.test.ts
@@ -1,0 +1,187 @@
+import { describe, expect, it, beforeEach, vi } from 'vitest';
+import type { AuthCredentials } from '../../src/auth/types.js';
+
+describe('Auth Provider', () => {
+  let setAuthCredentials: (credentials: AuthCredentials) => void;
+  let getAuthCredentials: () => AuthCredentials;
+  let hasAuthCredentials: () => boolean;
+  let ensureAuth: () => Promise<AuthCredentials>;
+
+  beforeEach(async () => {
+    // Reset modules to get fresh singleton state
+    vi.resetModules();
+
+    const providerModule = await import('../../src/auth/provider.js');
+    setAuthCredentials = providerModule.setAuthCredentials;
+    getAuthCredentials = providerModule.getAuthCredentials;
+    hasAuthCredentials = providerModule.hasAuthCredentials;
+    ensureAuth = providerModule.ensureAuth;
+  });
+
+  describe('setAuthCredentials', () => {
+    it('should store credentials', () => {
+      const credentials = {
+        mode: 'token' as const,
+        getAuthorizationHeader: () => 'Discogs token=test',
+      };
+
+      setAuthCredentials(credentials);
+
+      expect(hasAuthCredentials()).toBe(true);
+    });
+  });
+
+  describe('getAuthCredentials', () => {
+    it('should throw if credentials not initialized', () => {
+      expect(() => getAuthCredentials()).toThrow(
+        'Authentication credentials not initialized. Call ensureAuth() first.',
+      );
+    });
+
+    it('should return stored credentials', () => {
+      const credentials = {
+        mode: 'token' as const,
+        getAuthorizationHeader: () => 'Discogs token=mytoken',
+      };
+
+      setAuthCredentials(credentials);
+      const result = getAuthCredentials();
+
+      expect(result.mode).toBe('token');
+      expect(result.getAuthorizationHeader()).toBe('Discogs token=mytoken');
+    });
+  });
+
+  describe('hasAuthCredentials', () => {
+    it('should return false if credentials not set', () => {
+      expect(hasAuthCredentials()).toBe(false);
+    });
+
+    it('should return true after credentials are set', () => {
+      setAuthCredentials({
+        mode: 'oauth' as const,
+        getAuthorizationHeader: () => 'OAuth ...',
+      });
+
+      expect(hasAuthCredentials()).toBe(true);
+    });
+  });
+
+  describe('ensureAuth', () => {
+    it('should return existing credentials if already initialized', async () => {
+      const credentials = {
+        mode: 'token' as const,
+        getAuthorizationHeader: () => 'Discogs token=existing',
+      };
+
+      setAuthCredentials(credentials);
+      const result = await ensureAuth();
+
+      expect(result.mode).toBe('token');
+      expect(result.getAuthorizationHeader()).toBe('Discogs token=existing');
+    });
+
+    it('should initialize auth lazily when not yet initialized', async () => {
+      // Reset modules to get fresh state
+      vi.resetModules();
+
+      // Mock initializeAuth in index.js
+      vi.doMock('../../src/auth/index.js', async (importOriginal) => {
+        const original = await importOriginal<typeof import('../../src/auth/index.js')>();
+        return {
+          ...original,
+          initializeAuth: vi.fn(() =>
+            Promise.resolve({
+              mode: 'token' as const,
+              getAuthorizationHeader: () => 'Discogs token=lazy-init',
+            }),
+          ),
+        };
+      });
+
+      // Also mock the provider module to use the mocked index.js
+      vi.doMock('../../src/config.js', () => ({
+        config: {
+          discogs: {
+            authMode: 'token',
+            personalAccessToken: 'lazy-init',
+          },
+        },
+      }));
+
+      vi.doMock('../../src/utils.js', () => ({
+        log: {
+          info: vi.fn(),
+          warn: vi.fn(),
+          error: vi.fn(),
+        },
+      }));
+
+      vi.doMock('../../src/auth/oauth-flow.js', () => ({
+        performOAuthFlow: vi.fn(),
+      }));
+
+      vi.doMock('../../src/auth/oauth-signer.js', () => ({
+        buildOAuthHeader: vi.fn(),
+      }));
+
+      const { ensureAuth: freshEnsureAuth } = await import('../../src/auth/provider.js');
+
+      const result = await freshEnsureAuth();
+
+      expect(result.mode).toBe('token');
+    });
+
+    it('should only initialize once even with concurrent calls', async () => {
+      vi.resetModules();
+
+      vi.doMock('../../src/config.js', () => ({
+        config: {
+          discogs: {
+            authMode: 'token',
+            personalAccessToken: 'concurrent-test',
+          },
+        },
+      }));
+
+      vi.doMock('../../src/utils.js', () => ({
+        log: {
+          info: vi.fn(),
+          warn: vi.fn(),
+          error: vi.fn(),
+        },
+      }));
+
+      vi.doMock('../../src/auth/oauth-flow.js', () => ({
+        performOAuthFlow: vi.fn(),
+      }));
+
+      vi.doMock('../../src/auth/oauth-signer.js', () => ({
+        buildOAuthHeader: vi.fn(),
+      }));
+
+      // Re-import after mocking
+      const { ensureAuth: freshEnsureAuth } = await import('../../src/auth/provider.js');
+
+      // Spy on initializeAuth
+      const { initializeAuth } = await import('../../src/auth/index.js');
+      const initSpy = vi.spyOn({ initializeAuth }, 'initializeAuth');
+      initSpy.mockImplementation(async () => ({
+        mode: 'token' as const,
+        getAuthorizationHeader: () => 'Discogs token=concurrent-test',
+      }));
+
+      // Make concurrent calls
+      const [result1, result2, result3] = await Promise.all([
+        freshEnsureAuth(),
+        freshEnsureAuth(),
+        freshEnsureAuth(),
+      ]);
+
+      // All results should be the same
+      expect(result1.mode).toBe('token');
+      expect(result2.mode).toBe('token');
+      expect(result3.mode).toBe('token');
+    });
+  });
+});


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                                                                                                       
  - Adds OAuth 1.0a authentication as an alternative to Personal Access Tokens                                                                                                                                                                                                                                     
  - New `DISCOGS_AUTH_MODE` env var: `token`, `oauth`, or `auto` (default)                                                                                                                                                                                                                                         
  - OAuth flow opens browser for authorization and caches tokens locally

## Authentication modes

  | Mode | Behavior |
  |------|----------|
  | `token` | Uses `DISCOGS_PERSONAL_ACCESS_TOKEN`. Fails if not set. |
  | `oauth` | Starts interactive browser flow. Opens Discogs authorization page, waits for callback, caches tokens for future sessions. |
  | `auto` | Uses token if `DISCOGS_PERSONAL_ACCESS_TOKEN` is set, otherwise falls back to OAuth flow. This is the default. |

  ## OAuth flow details
  1. Starts a temporary local HTTP server on a random high port
  2. Opens browser to Discogs authorization page
  3. User authorizes the application
  4. Discogs redirects to local callback with verifier
  5. Exchanges verifier for access token
  6. Caches tokens in `~/.discogs_oauth_cache.json` (encrypted)
  7. Subsequent runs use cached tokens (re-authenticates if expired)

  ## Consumer key/secret
  The OAuth consumer key and secret are embedded in the source code. This is standard practice for open-source OAuth 1.0a CLI tools because:
  - These credentials identify the *application*, not individual users
  - Users still authorize with their own Discogs account
  - Users who prefer not to use embedded credentials can use the token flow instead

  ## New dependency
  - `get-port-please` - for dynamic port allocation during OAuth callback

  ## Test plan
  - [x] All 523 existing tests pass
  - [x] New auth module tests (index, oauth-cache, oauth-flow, oauth-signer, provider)
  - [x] Build succeeds
  - [x] Lint passes