### PR TITLE
fix: copy tsconfig*.json for Docker build

### DIFF
--- a/.changeset/fancy-queens-doubt.md
+++ b/.changeset/fancy-queens-doubt.md
@@ -1,0 +1,5 @@
+---
+'discogs-mcp-server': patch
+---
+
+fix: copy tsconfig\*.json for Docker build

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM node:22.12-alpine AS builder
 WORKDIR /app
 
 COPY package*.json ./
-COPY tsconfig.json ./
+COPY tsconfig*.json ./
 COPY tsup.config.ts ./
 COPY src ./src
 


### PR DESCRIPTION
### Description

Copies all `tsconfig*.json` files into the Docker builder stage (not just `tsconfig.json`). The build runs `tsc -p tsconfig.build.json`, which needs `tsconfig.build.json` in the image; without it, `docker build` fails after `tsup`.

### Checklist

- [ ] It's useful if your PR references an issue where it is discussed ahead of time
- [x] Adhere to [semantic messaging](https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716) and prefix your PR title with `feat:`, `fix:`, `chore:`, `docs:`, etc.
- [x] I’ve added tests if needed
- [x] I’ve updated documentation if applicable
- [x] I’ve tested this locally
- [x] Add a changeset (`pnpm changeset`) if necessary

### Tests and linting

- [x] Run the tests with `pnpm test`.
- [x] Run the lint check with `pnpm lint`.
- [x] Run the code formatting (prettier) check with `pnpm format`.