### PR TITLE
chore: add npm homepage metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "MCP server for Discogs",
   "license": "MIT",
   "author": "Christopher Kim <hi@cswkim.dev>",
+  "homepage": "https://github.com/cswkim/discogs-mcp-server#readme",
   "type": "module",
   "main": "dist/index.js",
   "module": "dist/index.js",


### PR DESCRIPTION
## Summary
- Add the npm `homepage` metadata field for `discogs-mcp-server`.
- Keep repository, bugs, dependencies, files, and runtime code unchanged.

## Verification
```sh
npm view discogs-mcp-server@0.5.7 name version homepage repository bugs deprecated --json
node metadata smoke check for homepage/repository/bugs
npm pack --dry-run --ignore-scripts
npx --yes pnpm@11.0.8 install --frozen-lockfile --ignore-scripts
npx --yes pnpm@11.0.8 run build
npx --yes pnpm@11.0.8 run test
npx --yes pnpm@11.0.8 run type-check
npx --yes pnpm@11.0.8 run format
git diff --check
```

Results: the published package currently exposes repository and bugs metadata but no homepage; metadata smoke passed; pack dry-run passed; pnpm frozen install passed with scripts ignored; build passed; test passed with 24 files and 485 tests; type-check passed; Prettier check passed; diff check passed.
